### PR TITLE
Add support for Kinja RSS feeds

### DIFF
--- a/pubfeeds/core/models.py
+++ b/pubfeeds/core/models.py
@@ -103,7 +103,7 @@ class Edition(models.Model):
                         article = Article.objects.get(identifier=entry.link, edition=self)
                     except Article.DoesNotExist:
                         article = Article(identifier=entry.link, section=section, edition=self)
-                    
+
                     if article.section != section:
                         continue  # If this article has been already created in another section, skip that shit.
 
@@ -115,7 +115,15 @@ class Edition(models.Model):
                     if entry.summary:
                         article.summary
 
-                    article.content = entry.content[0].get("value")
+                    if getattr(entry, 'content', None):
+                        # Bulbs RSS feeds use 'content' field
+                        article.content = entry.content[0].get("value")
+                    elif getattr(entry, 'description', None):
+                        # Kinja RSS feeds use 'description' field
+                        article.content = entry.description
+                    else:
+                        raise Exception('Could not determine item content')
+
                     article.publish_date = publish_date
 
                     article.save()


### PR DESCRIPTION
## Why? 

This fixes Kindle Publishing Feeds to work with Kinja RSS source feeds, now that AVC moved to Kinja.

The Kindle Feeds pull from both Onion (Bulbs) and AVC (Kinja) sources.

## Details

[Bulbs RSS](http://claim.avclub.com/feeds/rss?tags=tv&feature_types=-tv-club&full=true) uses the `content` field:

```
      <item>
            <title>Newswire: George R.R. Martin doesnâ€™t have time to watch Game Of Thrones</title>
            <description>
                       A SHORT BULBS DESCRIPTION, BUT NOT FULL CONTENT
            </description>
            
            <content:encoded>
                 FULL BULBS CONTENT
            </content:encoded>
```

While (AVC) [Kinja RSS](http://tv.avclub.com/rss?excerpt=false) uses the `description` field:

```
<item>
  <title>
    On Preacher, the talks break down between Jesse and everyone else
  </title>
  <link>
    http://www.avclub.com/on-preacher-the-talks-break-down-between-jesse-and-eve-1798463317
  </link>
  <description>
      FULL KINJA CONTENT
   </description>
```

## New Feed Entries

Most recent Kindle Feed edition[ is here](http://pubfeeds.theonion.com/onion/376/overview). The AVC sections (bottom) use this new logic. 